### PR TITLE
[codex] Fix CallFailed callInfo HTML response

### DIFF
--- a/protected/controllers/CallFailedController.php
+++ b/protected/controllers/CallFailedController.php
@@ -422,6 +422,7 @@
 
         public function actionCallInfo()
         {
+            header('Content-Type: text/html; charset=utf-8');
         ?>
 
 <style type="text/css">
@@ -554,5 +555,6 @@ table.blueTable tfoot .links a{
                     header('Location: http://' . $ip . '/mbilling?id=' . $model->id);
 
                 }
+                Yii::app()->end();
             }
     }


### PR DESCRIPTION
## What changed
This fixes the `callFailed/callInfo` page so failed-call details render as HTML instead of showing the raw `<style>` block and markup as plain text.

## Why
The action outputs inline HTML directly from the controller, but it did not explicitly send an HTML content type. On some environments the browser still rendered it, while on others it displayed the response as literal source text.

## Impact
Users opening failed-call details from CDR Failed in MBilling8 should now see the formatted SIP signaling table, matching the expected MBilling7 behavior.

## Root cause
`CallFailedController::actionCallInfo()` emitted raw HTML without forcing `Content-Type: text/html; charset=utf-8` and without explicitly ending the Yii response after output.

## Validation
- Verified the fix is isolated to `protected/controllers/CallFailedController.php`
- Confirmed the branch is pushed to the fork and ready for review
- PHP CLI was not available in this shell, so no local `php -l` syntax check could be run
