### PR TITLE
[codex] Fix PJSIP SIP user status and peer details

### DIFF
--- a/app/helper/Util.js
+++ b/app/helper/Util.js
@@ -700,6 +700,8 @@ Ext.define('Helper.Util', {
         return errors;
     },
     formatStatusImage: function (value) {
+        if (value === 'Unavail') value = 'Unavailable';
+        if (value === 'Unavailable') return '<img src="resources/images/UNKNOWN.png" /> ' + t(value);
         if (value.match(/^OK/g)) return '<img src="resources/images/registered.png" /> ' + t(value);
         else if (value.match(/^LAGGED/g)) return '<img src="resources/images/Unmonitored.png" /> ' + t(value);
         else return '<img src="resources/images/' + value + '.png" /> ' + t(value);

--- a/protected/components/AsteriskAccess.php
+++ b/protected/components/AsteriskAccess.php
@@ -128,6 +128,16 @@ class AsteriskAccess
         return $this->asmanager->Command("sip show peer " . $peer);
     }
 
+    public function pjsipShowEndpoint($endpoint)
+    {
+        return $this->asmanager->Command("pjsip show endpoint " . $endpoint);
+    }
+
+    public function pjsipShowAor($aor)
+    {
+        return $this->asmanager->Command("pjsip show aor " . $aor);
+    }
+
     public function pjsipShowContacts()
     {
         return $this->asmanager->Command('pjsip show contacts');

--- a/protected/controllers/SipController.php
+++ b/protected/controllers/SipController.php
@@ -273,7 +273,11 @@ class SipController extends Controller
 
 
                 if ($value['Aor'] == $name) {
-                    $attributes[$i]['lineStatus'] = $value['Status'] == 'Avail' ? 'OK' : $value['Status'];
+                    $status = $value['Status'] == 'Avail' ? 'OK' : $value['Status'];
+                    if ($status == 'Unavail') {
+                        $status = 'Unavailable';
+                    }
+                    $attributes[$i]['lineStatus'] = $status;
 
                     if (preg_match('/Avail/', $value['Status'])) {
                         $attributes[$i]['lineStatus'] .= ' ' . $value['server'];
@@ -330,13 +334,42 @@ class SipController extends Controller
         if ($modelSip->idUser->active == 0) {
             $sipShowPeer = 'The username is inactive';
         } else {
+            $peerName    = strlen($modelSip->techprefix) ? $modelSip->host : $modelSip->name;
+            $asterisk    = AsteriskAccess::instance();
+            $endpoint    = $asterisk->pjsipShowEndpoint($peerName);
+            $aor         = $asterisk->pjsipShowAor($peerName);
+            $contactsRaw = $asterisk->pjsipShowContacts();
 
-            $sipShowPeer = AsteriskAccess::instance()->sipShowPeer(strlen($modelSip->techprefix) ? $modelSip->host : $modelSip->name);
+            $contactLines = [];
+            if (isset($contactsRaw['data'])) {
+                foreach (explode("\n", $contactsRaw['data']) as $line) {
+                    $line = trim($line);
+                    if ($line === '' || strpos($line, 'Contact:') !== 0) {
+                        continue;
+                    }
+                    if (preg_match('/^Contact:\s+' . preg_quote($peerName, '/') . '\//', $line)) {
+                        $contactLines[] = $line;
+                    }
+                }
+            }
+
+            $sipShowPeer = "PJSIP Endpoint\n";
+            $sipShowPeer .= "====================\n";
+            $sipShowPeer .= isset($endpoint['data']) ? trim($endpoint['data']) : print_r($endpoint, true);
+            $sipShowPeer .= "\n\nPJSIP AOR\n";
+            $sipShowPeer .= "====================\n";
+            $sipShowPeer .= isset($aor['data']) ? trim($aor['data']) : print_r($aor, true);
+
+            if (count($contactLines)) {
+                $sipShowPeer .= "\n\nPJSIP Contacts\n";
+                $sipShowPeer .= "====================\n";
+                $sipShowPeer .= implode("\n", $contactLines);
+            }
         }
 
         echo json_encode([
             'success'     => true,
-            'sipshowpeer' => Yii::app()->session['isAdmin'] ? print_r($sipShowPeer, true) : '',
+            'sipshowpeer' => Yii::app()->session['isAdmin'] ? $sipShowPeer : '',
         ]);
     }
 


### PR DESCRIPTION
## What changed
This fixes two SIP Users regressions in MBilling8 after the SIP-to-PJSIP migration.

1. SIP user status no longer exposes the raw PJSIP `Unavail` value in the list.
2. The `SipShowPeer` panel now shows PJSIP details instead of calling the removed `sip show peer` command.

## Why
MBilling8 switched status collection to PJSIP, but the UI and diagnostics flow still partly assumed chan_sip output.

## Impact
- SIP Users status now renders a readable unavailable state instead of a broken icon/text combination.
- `SipShowPeer` now returns useful PJSIP endpoint, AOR, and contact details for troubleshooting.

## Root cause
- `setAttributesModels()` passed through raw PJSIP contact status like `Unavail`.
- `actionGetSipShowPeer()` still executed `sip show peer`, which is not valid in the Asterisk 20 PJSIP setup.

## Validation
- Verified the fix is isolated to the SIP/PJSIP status and peer-inspection flow
- Confirmed the branch is pushed to the fork and separated from the earlier `callInfo` PR
- PHP CLI was not available in this shell, so no local `php -l` syntax check could be run
