### PR TITLE
Fix WhatsApp webhook verification: CHttpRequest has no getIsGetRequest()

### DIFF
--- a/protected/controllers/WhatsappWebhookController.php
+++ b/protected/controllers/WhatsappWebhookController.php
@@ -7,7 +7,7 @@ class WhatsappWebhookController extends CController
 {
     public function actionIndex()
     {
-        if (Yii::app()->request->getIsGetRequest()) {
+        if (Yii::app()->request->getRequestType() === 'GET') {
             $this->verifyWebhook();
             return;
         }


### PR DESCRIPTION
## Problem

Meta's webhook verification for the WhatsApp Campaign feature always fails with **HTTP 500**.

When configuring the callback URL as documented in the wiki ([EN--whatsapp_campaign](https://github.com/magnussolution/magnusbilling8/wiki/EN--whatsapp_campaign)), Meta sends a `GET` request with `hub.mode`, `hub.verify_token` and `hub.challenge`. The controller then throws:

```
CException: HttpRequest and its behaviors do not have a method or closure named "getIsGetRequest".
in yii/framework/base/CComponent.php:264
```

Yii 1.1's `CHttpRequest` provides `getIsPostRequest()`, `getIsPutRequest()` and `getIsDeleteRequest()`, but **no `getIsGetRequest()`** — so "Verify and save" in the Meta app dashboard can never succeed, which blocks the whole WhatsApp Campaign feature.

## Fix

Use `getRequestType() === 'GET'` instead, which is available in Yii 1.1.

## Test

Reproduced and verified on a production MagnusBilling 8.0.0.4 install (Debian 12, PHP 8.2):

```
curl 'https://HOST/mbilling/index.php/whatsappWebhook/index?hub.mode=subscribe&hub.verify_token=TOKEN&hub.challenge=12345'
```

- Before: HTTP 500 (exception above)
- After: HTTP 200 with body `12345` — Meta's "Verify and save" completes successfully and `messages` events are received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)